### PR TITLE
Add basic cron shell

### DIFF
--- a/.github/workflows/drogon_cron.yml
+++ b/.github/workflows/drogon_cron.yml
@@ -1,0 +1,17 @@
+name: Deploy daily tests
+
+on:
+  schedule:
+    - cron: "0 6 * * *"  # Daily at 2am EST
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+
+  UpdateCoordinates:
+    uses: ./.github/workflows/update_regions_to_coordinates.yml
+    secrets:
+      OPENCAGE_API_KEY: ${{ secrets.OPENCAGE_API_KEY }}

--- a/.github/workflows/update_regions_to_coordinates.yml
+++ b/.github/workflows/update_regions_to_coordinates.yml
@@ -1,0 +1,23 @@
+name: Update coordinates
+on:
+  workflow_call:
+    secrets:
+      OPENCAGE_API_KEY:
+        required: true
+
+jobs:
+
+  run:
+    # Will read on PR dashboard as 'Deploy / UpdateCoordinates / ??'
+    # Action dashboard identified by 'Update coordinates'
+    # Requirement settings identified as 'UpdateCoordinates / ??'
+    name: ubuntu
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+
+    steps:
+      - name: Test
+        run: |
+          pwd
+          ls /mnt/backup/dandi


### PR DESCRIPTION
For testing purposes; needs to be on `main` even if not functional in order to be able to deploy (might need a first push to trigger as well)